### PR TITLE
Corrects the location of metadata when installing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.blg
 *.fdb_latexmk
 *.fls
+*.synctex.gz

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all:
 install:
 	install -d $(INPUTS) $(DOC) $(BIB)
 	cp -R inputs/* $(INPUTS)
-	cp README.md COPYING CHANGELOG BUGS $(INPUTS)
+	cp README.md COPYING CHANGELOG BUGS $(DOC)
 	@echo
 	@echo "Arquivos instalados com sucesso em $(INSTALLDIR)."
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all:
 install:
 	install -d $(INPUTS) $(DOC) $(BIB)
 	cp -R inputs/* $(INPUTS)
-	cp README.md COPYING CHANGELOG BUGS $(INSTALLDIR)
+	cp README.md COPYING CHANGELOG BUGS $(INPUTS)
 	@echo
 	@echo "Arquivos instalados com sucesso em $(INSTALLDIR)."
 	@echo


### PR DESCRIPTION
Files such as README and CHANGELOG were being copied to the texmf root,
not the package directory.