### PR TITLE
create new class option, noabntcite, to prevent loading abntex2cite automatically

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,8 +1,0 @@
-Lista de bugs
-=============
-
-1) mensagem ``Underfull [...] while \output is active''
-- Registro: 2003/03/08 avila
-- Status: PENDENTE
-- Desc: a msg aparece várias vezes enquanto o documento está sendo
-  processado; aparentemente tem algo a ver com os floating bodies

--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -63,6 +63,7 @@
 % outros
 \iiu@novodoc{nominatalocal}
 \DeclareOption{english}{\@englishtrue\OptionNotUsed}\newif\if@english
+\DeclareOption{noabntcite}{\@noabntcitetrue\OptionNotUsed}\newif\if@noabntcite
 \DeclareOption{oneside}{\AtEndOfClass{\@twosidefalse}\OptionNotUsed}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{report}}
 \ProcessOptions\relax
@@ -123,6 +124,8 @@
   \RequirePackage[T1]{fontenc}
 \fi
 
+\if@noabntcite
+\else
 \RequirePackage[
     % Habilita o uso de citações no formato autor-data.
 	alf,
@@ -131,6 +134,7 @@
     % não é o padrão do abntex2.
     abnt-emphasize=bf
 ]{abntex2cite}
+\fi
 
 %==============================================================================
 % Margens do texto


### PR DESCRIPTION
The current version of ```iiufrgs``` loads the ```abntex2cite``` package automatically to use the ABNT cite options. However, this prevents the user from using other citation styles (such as ```plain```, ```IEEEtran```, ...) via the ```\bibliographystyle``` command. 
When specifying the new ```noabntcite``` option, ```iiufrgs``` does not load ```abntex2cite``` automatically and leaves the citation style up to the user.