### PR TITLE
prevent overfull/underfull \vbox while \output

### DIFF
--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -136,6 +136,12 @@
 ]{abntex2cite}
 \fi
 
+\vfuzz=30pt % prevent overfull \vbox while \output is active
+
+% prevent underfull \vbox while \output is active:
+\edef\orig@output{\the\output}
+\output{\setbox\@cclv\vbox{\unvbox\@cclv\vspace{0pt plus 50pt}}\orig@output}
+
 %==============================================================================
 % Margens do texto
 %==============================================================================


### PR DESCRIPTION
Suggested fix for #25 