### PR TITLE
add empty line between chapters in list of listings

### DIFF
--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -556,6 +556,7 @@
         \addcontentsline{toc}{chapter}{\@chapapp\thechapter~\@chapappextra#1}%
         \addtocontents{lof}{\protect\addvspace{10\p@}}%
         \addtocontents{lot}{\protect\addvspace{10\p@}}%
+        \addtocontents{lol}{\protect\addvspace{10\p@}}%
         \pagestyle{iiufrgs}\let\ps@plain\ps@iiufrgs%
         \@makechapterhead{#2}{\@chappositioning}\@afterheading
 


### PR DESCRIPTION
Add empty line between chapters in list of listings, to be consistent with the list of tables/list of figures.
This patch does nothing if no listing package is loaded.
Tested with ```lstlisting```